### PR TITLE
Update elasticsearch to 1.4.4 and add Kibana 4

### DIFF
--- a/bin/control
+++ b/bin/control
@@ -47,6 +47,20 @@ function start() {
       echo "WARN: Could not find the compiled application versions/$NGINX_VERSION/bin/nginx, will not start"
   fi
 
+  echo "Starting Kibana"
+  if [ -f "$KIBANA_EXEC" ]; then
+      # Config for kibana
+      if [ -f "$OPENSHIFT_REPO_DIR/config/kibana.yml.erb" ]; then
+          oo-erb $OPENSHIFT_REPO_DIR/config/kibana.yml.erb > $OPENSHIFT_REPO_DIR/config/kibana.yml
+          cp $OPENSHIFT_REPO_DIR/config/kibana.yml $KIBANA_CONFIG_FILE
+      fi
+
+      nohup "$KIBANA_EXEC" -c "$KIBANA_CONFIG_FILE" 2>&1 >> $OPENSHIFT_ELASTICSEARCH_DIR/logs/kibana.log &
+      disown %1
+  else
+      echo "WARN: Could not find the compiled application kibana/bin/kibana, will not start"
+  fi
+
   echo "Starting ElasticSearch"
   export PUBLISH_HOST=$(python -c "import socket; print socket.gethostbyname('`hostname`')")
   export ES_HEAP_SIZE="`_es_heap_size`"
@@ -68,9 +82,12 @@ function stop() {
       wait_for_stop $pid
   fi
 
-  echo "Stopping ElasticSearch"
+  echo "Stopping ElasticSearch & Kibana"
   if [ -f $ES_PID_FILE ]; then
     local zpid=$(cat $ES_PID_FILE 2> /dev/null)
+  fi
+  if [ -f $KIBANA_PID_FILE ]; then
+    local kpid=$(cat $KIBANA_PID_FILE 2> /dev/null)
   fi
 
   if [ -n $zpid ]; then
@@ -80,6 +97,18 @@ function stop() {
       local TIMEOUT=10
       while [ $TIMEOUT -gt 0 ] &&  _is_running ; do
         /bin/kill -0 "$zpid" > /dev/null 2>&1  ||  break
+        sleep 1
+        let TIMEOUT=${TIMEOUT}-1
+      done
+    fi
+  fi
+  if [ -n $kpid ]; then
+    /bin/kill $kpid
+    local ret=$?
+    if [ $ret -eq 0 ]; then
+      local TIMEOUT=10
+      while [ $TIMEOUT -gt 0 ] &&  _is_running ; do
+        /bin/kill -0 "$kpid" > /dev/null 2>&1  ||  break
         sleep 1
         let TIMEOUT=${TIMEOUT}-1
       done

--- a/bin/install-version
+++ b/bin/install-version
@@ -2,7 +2,7 @@
 
 if [ $# -lt 1 ]; then
 	echo "Usage: $0 <ELASTICSEARCH-VERSION>"
-	echo "Example: $0 1.2.1"
+	echo "Example: $0 1.4.4"
 	exit 1
 fi
 

--- a/bin/setup
+++ b/bin/setup
@@ -3,11 +3,11 @@
 if [ ${ES_VERSION} ]; then
         echo $ES_VERSION
 else
-        echo 1.2.1
+        echo 1.4.4
 fi > $OPENSHIFT_ELASTICSEARCH_DIR/env/ES_VERSION
 
 if [ ${KIBANA_VERSION} ]; then
         echo $KIBANA_VERSION
 else
-        echo 3.1.2
+        echo 4.0.1
 fi > $OPENSHIFT_ELASTICSEARCH_DIR/env/KIBANA_VERSION

--- a/lib/util
+++ b/lib/util
@@ -4,6 +4,9 @@ export ES_CONFIG_DIR="$OPENSHIFT_REPO_DIR/config/"
 export ES_CONFIG_FILE="$ES_CONFIG_DIR/elasticsearch.yml"
 export ES_CONFIG_LOG_FILE="$ES_CONFIG_DIR/logging.yml"
 export ES_PID_FILE="$OPENSHIFT_ELASTICSEARCH_DIR/run/elasticsearch.pid"
+export KIBANA_EXEC="$OPENSHIFT_ELASTICSEARCH_DIR/kibana/bin/kibana"
+export KIBANA_CONFIG_FILE="$OPENSHIFT_ELASTICSEARCH_DIR/kibana/config/kibana.yml"
+export KIBANA_PID_FILE="$OPENSHIFT_ELASTICSEARCH_DIR/run/kibana.pid"
 export NGINX_PID_FILE="$OPENSHIFT_ELASTICSEARCH_DIR/run/nginx.pid"
 export NGINX_VERSION=${NGINX_VERSION:-1.4.4}
 export NGINX_EXEC="$OPENSHIFT_ELASTICSEARCH_DIR/nginx/versions/$NGINX_VERSION/bin/nginx"
@@ -35,7 +38,7 @@ function _install_kibana_version()
 
 	echo Downloading version $VERSION
 	mkdir $OPENSHIFT_ELASTICSEARCH_DIR/kibana
-	curl https://download.elasticsearch.org/kibana/kibana/kibana-$VERSION.tar.gz | tar xzf - --strip-components=1 -C $OPENSHIFT_ELASTICSEARCH_DIR/kibana
+	curl https://download.elasticsearch.org/kibana/kibana/kibana-$VERSION-linux-x64.tar.gz | tar xzf - --strip-components=1 -C $OPENSHIFT_ELASTICSEARCH_DIR/kibana
 }
 
 
@@ -110,9 +113,6 @@ function _build_config()
     echo
     SCALABLE=$S oo-erb "$FILE"
   done >> "${ES_CONFIG_FILE}"
-
-  # Config for kibana
-  cp conf/config.js $OPENSHIFT_ELASTICSEARCH_DIR/kibana/config.js
 }
 
 function _es_heap_size()

--- a/template/config/kibana.yml.erb
+++ b/template/config/kibana.yml.erb
@@ -1,0 +1,63 @@
+# Kibana is served by a back end server. This controls which port to use.
+port: 5601
+
+# The host to bind the server to.
+host: "<%= ENV['OPENSHIFT_ELASTICSEARCH_IP'] %>"
+
+# The Elasticsearch instance to use for all your queries.
+elasticsearch_url: "http://<%= ENV['OPENSHIFT_ELASTICSEARCH_IP'] %>:9200"
+
+# preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+# then the host you use to connect to *this* Kibana instance will be sent.
+elasticsearch_preserve_host: true
+
+# Kibana uses an index in Elasticsearch to store saved searches, visualizations
+# and dashboards. It will create a new index if it doesn't already exist.
+kibana_index: ".kibana"
+
+# If your Elasticsearch is protected with basic auth, this is the user credentials
+# used by the Kibana server to perform maintence on the kibana_index at statup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied thorugh
+# the Kibana server)
+# kibana_elasticsearch_username: user
+# kibana_elasticsearch_password: pass
+
+
+# The default application to load.
+default_app_id: "discover"
+
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
+# This must be > 0
+request_timeout: 300000
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Set to 0 to disable.
+shard_timeout: 0
+
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+verify_ssl: true
+
+# If you need to provide a CA certificate for your Elasticsarech instance, put
+# the path of the pem file here.
+# ca: /path/to/your/CA.pem
+
+# SSL for outgoing requests from the Kibana Server (PEM formatted)
+# ssl_key_file: /path/to/your/server.key
+# ssl_cert_file: /path/to/your/server.crt
+
+# Set the path to where you would like the process id file to be created.
+pid_file: <%= ENV['OPENSHIFT_ELASTICSEARCH_DIR'] %>/run/kibana.pid
+
+# Plugins that are included in the build, and no longer found in the plugins/ folder
+bundled_plugin_ids:
+  - plugins/dashboard/index
+  - plugins/discover/index
+  - plugins/doc/index
+  - plugins/kibana/index
+  - plugins/markdown_vis/index
+  - plugins/metric_vis/index
+  - plugins/settings/index
+  - plugins/table_vis/index
+  - plugins/vis_types/index
+  - plugins/visualize/index

--- a/template/nginx.conf.erb
+++ b/template/nginx.conf.erb
@@ -2,17 +2,14 @@ server {
     listen  <%= ENV['OPENSHIFT_ELASTICSEARCH_IP'] %>:<%= ENV['OPENSHIFT_ELASTICSEARCH_PORT'] %>;
     root    <%= ENV['OPENSHIFT_ELASTICSEARCH_DIR'] %>/kibana;
 
-    location @es {
-        proxy_pass       http://<%= ENV['OPENSHIFT_ELASTICSEARCH_IP'] %>:9200;
+    location @kibana {
+        rewrite ^/kibana/?(.*) /$1 break;
+        proxy_pass       http://<%= ENV['OPENSHIFT_ELASTICSEARCH_IP'] %>:5601;
         proxy_set_header Host      $host;
         proxy_set_header X-Real-IP $remote_addr;
     }
-    # Kibana URI is /kibana
-    location ~ ^/kibana/?$ {
-        try_files /index.html =404;
-    }
     location / {
         index  index.html index.htm;
-        try_files $uri @es;
+        try_files $uri @kibana;
     }
 }


### PR DESCRIPTION
**Hi there!**

I think it's about time to migrate elasticsearch to the new `1.4.4` version and get the new kibana working.

This PR includes both changes.

@caruccio let me know if this suits you.
